### PR TITLE
Human readable duration format

### DIFF
--- a/01-human-readable-duration-format/README.md
+++ b/01-human-readable-duration-format/README.md
@@ -1,0 +1,36 @@
+## Human readable duration format
+
+[Link on Codewars](https://www.codewars.com/kata/human-readable-duration-format/ruby)
+
+
+#### Description
+
+
+Your task in order to complete this Kata is to write a function which formats a duration, given as a number of seconds, in a human-friendly way.
+
+The function must accept a non-negative integer. If it is zero, it just returns `"now"`. Otherwise, the duration is expressed as a combination of years, days, hours, minutes and seconds.
+
+It is much easier to understand with an example:
+
+```ruby
+format_duration(62)    # returns "1 minute and 2 seconds"
+format_duration(3662)  # returns "1 hour, 1 minute and 2 seconds"
+```
+
+**For the purpose of this Kata, a year is 365 days and a day is 24 hours.**
+
+Note that spaces are important.
+
+####  Detailed rules
+
+The resulting expression is made of components like `4 seconds`, `1 year`, etc. In general, a positive integer and one of the valid units of time, separated by a space. The unit of time is used in plural if the integer is greater than 1.
+
+The components are separated by a comma and a space (`", "`). Except the last component, which is separated by `" and "`, just like it would be written in English.
+
+A more significant units of time will occur before than a least significant one. Therefore, `1 second and 1 year` is not correct, but `1 year and 1 second` is.
+
+Different components have different unit of times. So there is not repeated units like in `5 seconds and 1 second`
+
+A component will not appear at all if its value happens to be zero. Hence, `1 minute and 0 seconds` is not valid, but it should be just `1 minute`.
+
+A unit of time must be used "as much as possible". It means that the function should not return `61 seconds`, but `1 minute and 1 second` instead. Formally, the duration specified by of a component must not be greater than any valid more significant unit of time.

--- a/01-human-readable-duration-format/format_duration.rb
+++ b/01-human-readable-duration-format/format_duration.rb
@@ -1,0 +1,22 @@
+def format_duration(total)
+  raise "Function only accepts a non-negative integer" if total < 0
+  return "now" if total == 0
+
+  years, rs   = total.divmod(60 * 60 * 24 * 365)
+  days, rs    = rs.divmod(60 * 60 * 24)
+  hours, rs   = rs.divmod(60 * 60)
+  minutes, rs = rs.divmod(60)
+  seconds     = rs
+
+  wordify = ->(x, word) { x.zero? ? nil : "#{x} #{word}#{'s' unless x == 1}" }
+
+  words = [
+  	wordify.call(years, "year"),
+  	wordify.call(days, "day"),
+  	wordify.call(hours, "hour"),
+  	wordify.call(minutes, "minute"),
+  	wordify.call(seconds, "second")
+  ].compact
+
+  words.length == 1 ? words.last : words[0..-2].join(', ') + " and #{words.last}"
+end


### PR DESCRIPTION
## Human readable duration format

[Link on Codewars](https://www.codewars.com/kata/human-readable-duration-format/ruby)


#### Description


Your task in order to complete this Kata is to write a function which formats a duration, given as a number of seconds, in a human-friendly way.

The function must accept a non-negative integer. If it is zero, it just returns `"now"`. Otherwise, the duration is expressed as a combination of years, days, hours, minutes and seconds.

It is much easier to understand with an example:

```ruby
format_duration(62)    # returns "1 minute and 2 seconds"
format_duration(3662)  # returns "1 hour, 1 minute and 2 seconds"
```

**For the purpose of this Kata, a year is 365 days and a day is 24 hours.**

Note that spaces are important.

####  Detailed rules

The resulting expression is made of components like `4 seconds`, `1 year`, etc. In general, a positive integer and one of the valid units of time, separated by a space. The unit of time is used in plural if the integer is greater than 1.

The components are separated by a comma and a space (`", "`). Except the last component, which is separated by `" and "`, just like it would be written in English.

A more significant units of time will occur before than a least significant one. Therefore, `1 second and 1 year` is not correct, but `1 year and 1 second` is.

Different components have different unit of times. So there is not repeated units like in `5 seconds and 1 second`

A component will not appear at all if its value happens to be zero. Hence, `1 minute and 0 seconds` is not valid, but it should be just `1 minute`.

A unit of time must be used "as much as possible". It means that the function should not return `61 seconds`, but `1 minute and 1 second` instead. Formally, the duration specified by of a component must not be greater than any valid more significant unit of time.