### PR TITLE
Multiples of 3 or 5

### DIFF
--- a/04-multiples-of-3-or-5/README.md
+++ b/04-multiples-of-3-or-5/README.md
@@ -1,0 +1,7 @@
+## Multiples of 3 or 5
+
+If we list all the natural numbers below 10 that are multiples of 3 or 5, we get 3, 5, 6 and 9. The sum of these multiples is 23.
+
+Finish the solution so that it returns the sum of all the multiples of 3 or 5 below the number passed in.
+
+> Note: If the number is a multiple of both 3 and 5, only count it once.

--- a/04-multiples-of-3-or-5/solution.rb
+++ b/04-multiples-of-3-or-5/solution.rb
@@ -1,3 +1,3 @@
 def solution(number)
-  (2...number).select { |n| n.modulo(3).zero? || n.modulo(5).zero? }.inject(0){ |sum, n| sum + n }
+  (2...number).select { |n| n.modulo(3).zero? || n.modulo(5).zero? }.inject(&:+)
 end

--- a/04-multiples-of-3-or-5/solution.rb
+++ b/04-multiples-of-3-or-5/solution.rb
@@ -1,0 +1,3 @@
+def solution(number)
+  (2...number).select { |n| n.modulo(3).zero? || n.modulo(5).zero? }.inject(0){ |sum, n| sum + n }
+end


### PR DESCRIPTION
## Multiples of 3 or 5

If we list all the natural numbers below 10 that are multiples of 3 or 5, we get 3, 5, 6 and 9. The sum of these multiples is 23.

Finish the solution so that it returns the sum of all the multiples of 3 or 5 below the number passed in.

> Note: If the number is a multiple of both 3 and 5, only count it once.